### PR TITLE
Remove insecure Ruby versions due to ruby_dep

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,11 @@
 language: ruby
 rvm:
-- 2.3.0
-- 2.2.2
-- 2.1.0
-- 2.0.0
-- 1.9.3
+- 2.3
+- 2.2
 - ruby-head
 matrix:
   allow_failures:
     - rvm: ruby-head
-    - rvm: jruby-1.7.12
 addons:
   code_climate:
     repo_token: 6e1cff9fab6a2878c20e9935e9fbe551bb056ad03347f05faef813c058fc6f8f


### PR DESCRIPTION
Travis is failing all of our pre-2.2 builds because it is now using the `ruby_dep` gem to push people away from old and insecure Rubies.

Ideally, we should support as many versions as possible, but the lack of a CI build on previous versions will make this much harder.

We have a couple of options:
1. Move away from Travis or disable `ruby_dep`
2. Drop official support/testing on insecure Rubies

Personally, I think security takes precedence and while having your build tool play up is a really pain, I'd rather be pushed to upgrade rather than risk sitting on a Ruby version with known exploits.

This PR will drop testing on older Rubies and makes our position that official support will only extend to 2 recent Rubies, with unofficial support for older rubies probable but not guaranteed.