### PR TITLE
Fix semver tasks to update version.rb nested inside in gem projects

### DIFF
--- a/history.rdoc
+++ b/history.rdoc
@@ -1,3 +1,5 @@
+* Fix semver tasks to update version.rb nested inside in gem projects
+
 == v3.1.2 (10 July 2019)
 
 == v3.1.1 (05 October 2018)

--- a/lib/semver_versioning.rb
+++ b/lib/semver_versioning.rb
@@ -61,7 +61,7 @@ module RakeNBake
     end
 
     def self.update_version_rb
-      version_files = Dir.glob('lib{,/*}/version.rb').uniq
+      version_files = Dir.glob('lib{,/**/*}/version.rb').uniq
       return unless version_files.size == 1
       version_file = version_files[0]
 


### PR DESCRIPTION
Looks for version.rb in both ./lib/ and ./lib/**/* so that versions can be auto incremented on gems, e.g:

- `lib/version.rb`
- `lib/foo/version.rb`
- `lib/foo/bar/version.rb`

Fixes #21